### PR TITLE
Fixing reader creation logic in examples

### DIFF
--- a/example/common/common.go
+++ b/example/common/common.go
@@ -21,21 +21,23 @@ func main() {
 	flag.Parse()
 
 	// Read given file or from STDIN
-	var file io.Reader
+	var logReader io.Reader
+
 	if logFile == "dummy" {
-		file = strings.NewReader(`89.234.89.123 [08/Nov/2013:13:39:18 +0000] "GET /api/foo/bar HTTP/1.1"`)
+		logReader = strings.NewReader(`89.234.89.123 [08/Nov/2013:13:39:18 +0000] "GET /api/foo/bar HTTP/1.1"`)
 	} else if logFile == "-" {
-		file = os.Stdin
+		logReader = os.Stdin
 	} else {
 		file, err := os.Open(logFile)
 		if err != nil {
 			panic(err)
 		}
+		logReader = file
 		defer file.Close()
 	}
 
 	// Create reader and call Read method until EOF
-	reader := gonx.NewReader(file, format)
+	reader := gonx.NewReader(logReader, format)
 	for {
 		rec, err := reader.Read()
 		if err == io.EOF {

--- a/example/nginx/nginx.go
+++ b/example/nginx/nginx.go
@@ -23,16 +23,18 @@ func main() {
 	flag.Parse()
 
 	// Read given file or from STDIN
-	var file io.Reader
+	var logReader io.Reader
+	var err error
 	if logFile == "dummy" {
-		file = strings.NewReader(`89.234.89.123 [08/Nov/2013:13:39:18 +0000] "GET /api/foo/bar HTTP/1.1"`)
+		logReader = strings.NewReader(`89.234.89.123 [08/Nov/2013:13:39:18 +0000] "GET /api/foo/bar HTTP/1.1"`)
 	} else if logFile == "-" {
-		file = os.Stdin
+		logReader = os.Stdin
 	} else {
 		file, err := os.Open(logFile)
 		if err != nil {
 			panic(err)
 		}
+		logReader = file
 		defer file.Close()
 	}
 
@@ -45,15 +47,16 @@ func main() {
             }
         `)
 	} else {
-		nginxConfig, err := os.Open(conf)
+		nginxConfigFile, err := os.Open(conf)
 		if err != nil {
 			panic(err)
 		}
-		defer nginxConfig.Close()
+		nginxConfig = nginxConfigFile
+		defer nginxConfigFile.Close()
 	}
 
 	// Read from STDIN and use log_format to parse log records
-	reader, err := gonx.NewNginxReader(file, nginxConfig, format)
+	reader, err := gonx.NewNginxReader(logReader, nginxConfig, format)
 	if err != nil {
 		panic(err)
 	}

--- a/example/reduce/reduce.go
+++ b/example/reduce/reduce.go
@@ -24,16 +24,17 @@ func main() {
 	parser := gonx.NewParser(format)
 
 	// Read given file or from STDIN
-	var file io.Reader
+	var logReader io.Reader
 	if logFile == "dummy" {
-		file = strings.NewReader(`89.234.89.123 [08/Nov/2013:13:39:18 +0000] "GET /t/100x100/foo/bar.jpeg HTTP/1.1" 200 1027 2430 0.014 "100x100" 10 1`)
+		logReader = strings.NewReader(`89.234.89.123 [08/Nov/2013:13:39:18 +0000] "GET /t/100x100/foo/bar.jpeg HTTP/1.1" 200 1027 2430 0.014 "100x100" 10 1`)
 	} else if logFile == "-" {
-		file = os.Stdin
+		logReader = os.Stdin
 	} else {
 		file, err := os.Open(logFile)
 		if err != nil {
 			panic(err)
 		}
+		logReader = file
 		defer file.Close()
 	}
 
@@ -42,7 +43,7 @@ func main() {
 		&gonx.Avg{[]string{"request_time", "read_time", "gen_time"}},
 		&gonx.Sum{[]string{"body_bytes_sent"}},
 		&gonx.Count{})
-	output := gonx.MapReduce(file, parser, reducer)
+	output := gonx.MapReduce(logReader, parser, reducer)
 	for res := range output {
 		// Process the record... e.g.
 		fmt.Printf("Parsed entry: %+v\n", res)


### PR DESCRIPTION
Previously the creation of an actual file used := to assign the file and err.
This shadowed the var declaration of file, leaving it uninitialized and causing
seg faults when the scanner tried to read data.