### PR TITLE
Extracting StringParser interface

### DIFF
--- a/mapreduce.go
+++ b/mapreduce.go
@@ -15,7 +15,7 @@ func handleError(err error) {
 // when result will be readed from reducer's output channel, but the mapper
 // works and fills input Entries channel until all lines will be read from
 // the fiven file.
-func MapReduce(file io.Reader, parser *Parser, reducer Reducer) chan *Entry {
+func MapReduce(file io.Reader, parser StringParser, reducer Reducer) chan *Entry {
 	// Input file lines. This channel is unbuffered to publish
 	// next line to handle only when previous is taken by mapper.
 	var lines = make(chan string)

--- a/parser.go
+++ b/parser.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+// StringParser is the interface that wraps the ParseString method.
+type StringParser interface {
+	ParseString(line string) (entry *Entry, err error)
+}
+
 // Log record parser. Use specific constructors to initialize it.
 type Parser struct {
 	format string


### PR DESCRIPTION
This PR intruduces extraction of `StringParser` interface to make it possible to use custom parsers with `MapReduce`.