### PR TITLE
Make Reader use the StringParser interface

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -6,26 +6,26 @@ import (
 	"strings"
 )
 
-// Shortcut for the map of strings
+// Fields is a shortcut for the map of strings
 type Fields map[string]string
 
-// Parsed log record. Use Get method to retrieve a value by name instead of
+// Entry is a parsed log record. Use Get method to retrieve a value by name instead of
 // threating this as a map, because inner representation is in design.
 type Entry struct {
 	fields Fields
 }
 
-// Creates an empty Entry to be filled later
+// NewEmptyEntry creates an empty Entry to be filled later
 func NewEmptyEntry() *Entry {
 	return &Entry{make(Fields)}
 }
 
-// Creates an Entry with fiven fields
+// NewEntry creates an Entry with fiven fields
 func NewEntry(fields Fields) *Entry {
 	return &Entry{fields}
 }
 
-// Return entry field value by name or empty string and error if it
+// Field returns an entry field value by name or empty string and error if it
 // does not exist.
 func (entry *Entry) Field(name string) (value string, err error) {
 	value, ok := entry.fields[name]
@@ -35,7 +35,7 @@ func (entry *Entry) Field(name string) (value string, err error) {
 	return
 }
 
-// Return entry field value as float64. Return nil if field does not exist
+// FloatField returns an entry field value as float64. Return nil if field does not exist
 // and conversion error if cannot cast a type.
 func (entry *Entry) FloatField(name string) (value float64, err error) {
 	tmp, err := entry.Field(name)
@@ -45,31 +45,32 @@ func (entry *Entry) FloatField(name string) (value float64, err error) {
 	return
 }
 
-// Field value setter
+// SetField sets the value of a field
 func (entry *Entry) SetField(name string, value string) {
 	entry.fields[name] = value
 }
 
-// Float field value setter. It accepts float64, but still store it as a
+// SetFloatField is a Float field value setter. It accepts float64, but still store it as a
 // string in the same fields map. The precision is 2, its enough for log
 // parsing task
 func (entry *Entry) SetFloatField(name string, value float64) {
 	entry.SetField(name, strconv.FormatFloat(value, 'f', 2, 64))
 }
 
-// Integer field value setter. It accepts float64, but still store it as a
+// SetUintField is a Integer field value setter. It accepts float64, but still store it as a
 // string in the same fields map.
 func (entry *Entry) SetUintField(name string, value uint64) {
 	entry.SetField(name, strconv.FormatUint(uint64(value), 10))
 }
 
 // Merge two entries by updating values for master entry with given.
-func (master *Entry) Merge(entry *Entry) {
-	for name, value := range entry.fields {
-		master.SetField(name, value)
+func (entry *Entry) Merge(merge *Entry) {
+	for name, value := range merge.fields {
+		entry.SetField(name, value)
 	}
 }
 
+// FieldsHash returns a hash of all fields
 func (entry *Entry) FieldsHash(fields []string) string {
 	var key []string
 	for _, name := range fields {
@@ -82,6 +83,7 @@ func (entry *Entry) FieldsHash(fields []string) string {
 	return strings.Join(key, ";")
 }
 
+// Partial returns a partial field entry with the specified fields
 func (entry *Entry) Partial(fields []string) *Entry {
 	partial := NewEmptyEntry()
 	for _, name := range fields {

--- a/filter.go
+++ b/filter.go
@@ -11,7 +11,7 @@ type Filter interface {
 	Filter(*Entry) *Entry
 }
 
-// Implements Filter interface to filter Entries with timestamp fields within
+// Datetime implements the Filter interface to filter Entries with timestamp fields within
 // the specified datetime interval.
 type Datetime struct {
 	Field  string
@@ -20,7 +20,7 @@ type Datetime struct {
 	End    time.Time
 }
 
-// Check field value to be in desired datetime range.
+// Filter checks a field value to be in desired datetime range.
 func (i *Datetime) Filter(entry *Entry) (validEntry *Entry) {
 	val, err := entry.Field(i.Field)
 	if err != nil {
@@ -38,7 +38,7 @@ func (i *Datetime) Filter(entry *Entry) (validEntry *Entry) {
 	return
 }
 
-// Reducer interface too. Go through input and apply Filter.
+// Reduce implements the Reducer interface. Go through input and apply Filter.
 func (i *Datetime) Reduce(input chan *Entry, output chan *Entry) {
 	for entry := range input {
 		if valid := i.Filter(entry); valid != nil {

--- a/mapreduce.go
+++ b/mapreduce.go
@@ -11,7 +11,7 @@ func handleError(err error) {
 	//fmt.Fprintln(os.Stderr, err)
 }
 
-// Iterate over given file and map each it's line into Entry record using
+// MapReduce iterates over given file and map each it's line into Entry record using
 // parser and apply reducer to the Entries channel. Execution terminates
 // when result will be readed from reducer's output channel, but the mapper
 // works and fills input Entries channel until all lines will be read from

--- a/parser.go
+++ b/parser.go
@@ -13,13 +13,13 @@ type StringParser interface {
 	ParseString(line string) (entry *Entry, err error)
 }
 
-// Log record parser. Use specific constructors to initialize it.
+// Parser is a log record parser. Use specific constructors to initialize it.
 type Parser struct {
 	format string
 	regexp *regexp.Regexp
 }
 
-// Returns a new Parser, use given log format to create its internal
+// NewParser returns a new Parser, use given log format to create its internal
 // strings parsing regexp.
 func NewParser(format string) *Parser {
 	re := regexp.MustCompile(`\\\$([a-z_]+)(\\?(.))`).ReplaceAllString(
@@ -27,8 +27,8 @@ func NewParser(format string) *Parser {
 	return &Parser{format, regexp.MustCompile(fmt.Sprintf("^%v$", strings.Trim(re, " ")))}
 }
 
-// Parse log file line using internal format regexp. If line do not match
-// given format an error will be returned.
+// ParseString parses a log file line using internal format regexp. If a line
+// does not match the given format an error will be returned.
 func (parser *Parser) ParseString(line string) (entry *Entry, err error) {
 	re := parser.regexp
 	fields := re.FindStringSubmatch(line)
@@ -48,8 +48,9 @@ func (parser *Parser) ParseString(line string) (entry *Entry, err error) {
 	return
 }
 
-// NewNginxParser parse nginx conf file to find log_format with given name and
-// returns parser for this format. It returns an error if cannot find the needle.
+// NewNginxParser parses the nginx conf file to find log_format with the given
+// name and returns a parser for this format. It returns an error if cannot find
+// the given log format.
 func NewNginxParser(conf io.Reader, name string) (parser *Parser, err error) {
 	scanner := bufio.NewScanner(conf)
 	re := regexp.MustCompile(fmt.Sprintf(`^\s*log_format\s+%v\s+(.+)\s*$`, name))

--- a/reader.go
+++ b/reader.go
@@ -4,14 +4,14 @@ import (
 	"io"
 )
 
-// Log file reader. Use specific constructors to create it.
+// Reader is a log file reader. Use specific constructors to create it.
 type Reader struct {
 	file    io.Reader
-	parser  *Parser
+	parser  StringParser
 	entries chan *Entry
 }
 
-// Creates reader for custom log format.
+// NewReader creates a reader for a custom log format.
 func NewReader(logFile io.Reader, format string) *Reader {
 	return &Reader{
 		file:   logFile,
@@ -19,7 +19,7 @@ func NewReader(logFile io.Reader, format string) *Reader {
 	}
 }
 
-// Creates reader for nginx log format. Nginx config parser will be used
+// NewNginxReader creates a reader for the nginx log format. Nginx config parser will be used
 // to get particular format from the conf file.
 func NewNginxReader(logFile io.Reader, nginxConf io.Reader, formatName string) (reader *Reader, err error) {
 	parser, err := NewNginxParser(nginxConf, formatName)
@@ -33,7 +33,7 @@ func NewNginxReader(logFile io.Reader, nginxConf io.Reader, formatName string) (
 	return
 }
 
-// Get next parsed Entry from the log file. Return EOF if there is no Entries to read.
+// Read next parsed Entry from the log file. Return EOF if there are no Entries to read.
 func (r *Reader) Read() (entry *Entry, err error) {
 	if r.entries == nil {
 		r.entries = MapReduce(r.file, r.parser, new(ReadAll))


### PR DESCRIPTION
The StringParser interface was defined, but not used by the Reader. I want to be able to override the Parser to use support 2 alternative formats.

Also fix linting errors. Most of these were comment changes. In some places I have fixed the english as well.