### PR TITLE
Need a way to provide a custom StringParser to the Reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -13,9 +13,14 @@ type Reader struct {
 
 // NewReader creates a reader for a custom log format.
 func NewReader(logFile io.Reader, format string) *Reader {
+	return NewParserReader(logFile, NewParser(format))
+}
+
+// NewParserReader creates a reader with the given parser
+func NewParserReader(logFile io.Reader, parser StringParser) *Reader {
 	return &Reader{
 		file:   logFile,
-		parser: NewParser(format),
+		parser: parser,
 	}
 }
 


### PR DESCRIPTION
I realised that there was still no way of providing a custom StringParser to a Reader since the parser is private. This adds a new constructor.