### PR TITLE
Don't require format to be exhaustive

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -24,7 +24,7 @@ type Parser struct {
 func NewParser(format string) *Parser {
 	re := regexp.MustCompile(`\\\$([a-z_]+)(\\?(.))`).ReplaceAllString(
 		regexp.QuoteMeta(format+" "), "(?P<$1>[^$3]*)$2")
-	return &Parser{format, regexp.MustCompile(fmt.Sprintf("^%v$", strings.Trim(re, " ")))}
+	return &Parser{format, regexp.MustCompile(fmt.Sprintf("^%v", strings.Trim(re, " ")))}
 }
 
 // ParseString parses a log file line using internal format regexp. If a line

--- a/parser_test.go
+++ b/parser_test.go
@@ -18,7 +18,7 @@ func TestParser(t *testing.T) {
 
 			Convey("Test format to regexp translation", func() {
 				So(parser.regexp.String(), ShouldEqual,
-					`^(?P<remote_addr>[^ ]*) \[(?P<time_local>[^]]*)\] "(?P<request>[^"]*)" (?P<status>[^ ]*)$`)
+					`^(?P<remote_addr>[^ ]*) \[(?P<time_local>[^]]*)\] "(?P<request>[^"]*)" (?P<status>[^ ]*)`)
 			})
 
 			Convey("ParseString", func() {


### PR DESCRIPTION
Currently supplying a log format requires it to be exhaustive, match until end of line.

I want to be able to match partial log entries, this was if (in my use case there is) additional data in the log line that i don't care about there is no need to parse it out.