### PR TITLE
Add Special Regex for http_x_forwarded_for Var

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -21,7 +21,8 @@ type Parser struct {
 
 func getSpecialNginxRegexes() map[string]string {
 	return map[string]string{
-		"http_x_forwarded_for": `[^ ]*(, [^ ]+)*`}
+		"http_x_forwarded_for": `[^ ]*(, [^ ]+)*`,
+		"remote_user":          `[^"]*`}
 }
 
 // NewParser returns a new Parser, use given log format to create its internal


### PR DESCRIPTION
Since there's the possibility for the http_x_forwarded_for Nginx
variable to contain a space (right after the comma separating two IP
addresses), create a regex for handling this variable. Change the way
the Nginx format regex is created by adding logic for including special
regexes.

Fixes satyrius/gonx#36

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>