### PR TITLE
Makes NewNginxParser tolerant of log_format directives with newlines

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -68,7 +68,7 @@ func (parser *Parser) ParseString(line string) (entry *Entry, err error) {
 // the given log format.
 func NewNginxParser(conf io.Reader, name string) (parser *Parser, err error) {
 	scanner := bufio.NewScanner(conf)
-	re := regexp.MustCompile(fmt.Sprintf(`^\s*log_format\s+%v\s+(.+)\s*$`, name))
+	re := regexp.MustCompile(fmt.Sprintf(`^\s*log_format\s+%s\s*(.*)\s*$`, name))
 	found := false
 	var format string
 	for scanner.Scan() {
@@ -81,13 +81,18 @@ func NewNginxParser(conf io.Reader, name string) (parser *Parser, err error) {
 				continue
 			}
 			found = true
+			// remove the "log_format <name>" from the line, leaving only the (potential)
+			// formatting directives.
 			line = formatDef[1]
 		} else {
 			line = scanner.Text()
 		}
-		// Look for a definition end
+		// Look for the end of the definition
 		re = regexp.MustCompile(`^\s*(.*?)\s*(;|$)`)
 		lineSplit := re.FindStringSubmatch(line)
+
+		// If there are any formatting directives on this line,
+		// add them to the format string
 		if l := len(lineSplit[1]); l > 2 {
 			format += lineSplit[1][1 : l-1]
 		}


### PR DESCRIPTION
This PR makes slight modifications to the regex used in the `NewNginxParser` func, so that it correctly parses `nginx` `log_format` directives that contain newlines after the name.

This is best illustrated with an example.

This is perfectly valid `nginx` config (elided for brevity):

```
http {
  ...

  log_format main 
    '$remote_addr - $remote_user [$time_local] '
    '"$request" $status '
    '"$http_referer" "$http_user_agent"';

  ... 
}
```

Previously, the NewNginxParser regex would not properly match the `log_format main` line in such a case, since it expected to find one or more characters in a capture group before the end of the line.  This would work if we "hacked" the line to include trailing whitespace, but that solution is error-prone and literally invisible to the naked eye. 😄 

This PR changes that, and makes one more trivial change to that particular regex: it uses the standard `%s` formatting verb when building the regex, rather than the `%v`.  

The rest of the PR consists of comments and additional test cases.

Let me know if you have any concerns, or if you'd like further modifications to be made.  Thanks for looking!